### PR TITLE
Harden questionnaire and network parsing against locale differences

### DIFF
--- a/Assets/BOforUnity/Scripts/Optimizer.cs
+++ b/Assets/BOforUnity/Scripts/Optimizer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -24,16 +25,15 @@ namespace BOforUnity.Scripts
         /// <summary>
         /// This method updates the values of the parameters in the optimization process using the data in the
         /// CSV file at the specified currentIndex. It loops through each parameter in the parameters dictionary
-        /// and sets its Value property to the corresponding value in the CSV file at the given index. After
-        /// updating the parameter values, it starts a coroutine called ShowIndexChange, which likely shows some
-        /// kind of visual feedback to the user that the parameter values have changed.
+        /// and sets its Value property to the corresponding value in the CSV file at the given index using
+        /// invariant culture parsing so number formats remain consistent across locales.
         /// </summary>
         /// <param name="currentIndex"></param>
         public void UpdateParameter(int currentIndex)
         {
             foreach (var pa in _bomanager.parameters)
             {
-                pa.value.Value = float.Parse(_csvData[currentIndex][pa.key].ToString());
+                pa.value.Value = float.Parse(_csvData[currentIndex][pa.key].ToString(), CultureInfo.InvariantCulture);
             }
         }
 

--- a/Assets/BOforUnity/Scripts/SocketNetwork.cs
+++ b/Assets/BOforUnity/Scripts/SocketNetwork.cs
@@ -141,12 +141,12 @@ namespace BOforUnity.Scripts
                 }
                 else if (strArr[0] == "coverage")
                 {
-                    coverage = Convert.ToSingle(strArr[1]);
+                    coverage = float.Parse(strArr[1], CultureInfo.InvariantCulture);
                     Debug.Log($"coverage {coverage}");
                 }
                 else if (strArr[0] == "tempCoverage")
                 {
-                    tempCoverage = Convert.ToSingle(strArr[1]);
+                    tempCoverage = float.Parse(strArr[1], CultureInfo.InvariantCulture);
                     Debug.Log($"tempCoverage {tempCoverage}");
                 }
                 else
@@ -248,7 +248,7 @@ namespace BOforUnity.Scripts
                 c += ob.key + ",";
             }
 
-            // Delete last / from string a and c
+            // Remove the trailing comma segments that were appended while building the strings
             b = b.Substring(0, b.Length - 1);
             c = c.Substring(0, c.Length - 1);
 

--- a/Assets/BOforUnity/Scripts/TargetClickerEvaluator.cs
+++ b/Assets/BOforUnity/Scripts/TargetClickerEvaluator.cs
@@ -48,10 +48,10 @@ namespace BOforUnity.Scripts
 
             boManager = GameObject.FindWithTag("BOforUnityManager")?.GetComponent<BoForUnityManager>();
 
-            StartCoroutine(Start());
+            StartCoroutine(StartGame());
         }
 
-        private IEnumerator Start()
+        private IEnumerator StartGame()
         {
             // Read normalized params from BO
             float u_size = 0.5f, u_ecc = 0.5f;

--- a/Assets/BOforUnity/Tests/PlayMode/MainThreadDispatcherPlayModeTests.cs
+++ b/Assets/BOforUnity/Tests/PlayMode/MainThreadDispatcherPlayModeTests.cs
@@ -1,0 +1,51 @@
+using System.Collections;
+using System.Threading;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using BOforUnity.Scripts;
+
+namespace BOforUnity.Tests.PlayMode
+{
+    public class MainThreadDispatcherPlayModeTests
+    {
+        [UnityTest]
+        public IEnumerator Execute_ProcessesQueuedActionsOnMainThreadInOrder()
+        {
+            var dispatcherGo = new GameObject("MainThreadDispatcherTest");
+            var dispatcher = dispatcherGo.AddComponent<MainThreadDispatcher>();
+
+            var mainThreadId = Thread.CurrentThread.ManagedThreadId;
+            int? actionThreadId = null;
+            int? genericActionThreadId = null;
+            string executionTrace = string.Empty;
+
+            var worker = new Thread(() =>
+            {
+                MainThreadDispatcher.Execute(() =>
+                {
+                    actionThreadId = Thread.CurrentThread.ManagedThreadId;
+                    executionTrace += "A";
+                });
+
+                MainThreadDispatcher.Execute<string>(marker =>
+                {
+                    genericActionThreadId = Thread.CurrentThread.ManagedThreadId;
+                    executionTrace += marker;
+                }, "B");
+            });
+
+            worker.Start();
+            worker.Join();
+
+            yield return null; // allow dispatcher Update to run once
+
+            Assert.That(executionTrace, Is.EqualTo("AB"), "Queued actions should execute in FIFO order.");
+            Assert.That(actionThreadId, Is.EqualTo(mainThreadId), "Actions must execute on the main Unity thread.");
+            Assert.That(genericActionThreadId, Is.EqualTo(mainThreadId), "Generic Execute overload must run on main thread.");
+
+            Object.DestroyImmediate(dispatcher);
+            Object.DestroyImmediate(dispatcherGo);
+        }
+    }
+}

--- a/Assets/QuestionnaireToolkit/Scripts/QTQuestionnaireManager.cs
+++ b/Assets/QuestionnaireToolkit/Scripts/QTQuestionnaireManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
  using System.Text;
@@ -650,9 +651,21 @@ namespace QuestionnaireToolkit.Scripts
             // reads and parses .json input file
             var JSONString = File.ReadAllText(jsonPath);
             var N = JSON.Parse(JSONString);
-            pageBackgroundColor = new Color(float.Parse(N["page_background_color"][0]), float.Parse(N["page_background_color"][1]), float.Parse(N["page_background_color"][2]), float.Parse(N["page_background_color"][3]));
-            pageBottomColor = new Color(float.Parse(N["page_panel_color"][0]), float.Parse(N["page_panel_color"][1]), float.Parse(N["page_panel_color"][2]), float.Parse(N["page_panel_color"][3]));
-            highlightColor = new Color(float.Parse(N["highlight_color"][0]), float.Parse(N["highlight_color"][1]), float.Parse(N["highlight_color"][2]), float.Parse(N["highlight_color"][3]));
+            pageBackgroundColor = new Color(
+                float.Parse(N["page_background_color"][0], CultureInfo.InvariantCulture),
+                float.Parse(N["page_background_color"][1], CultureInfo.InvariantCulture),
+                float.Parse(N["page_background_color"][2], CultureInfo.InvariantCulture),
+                float.Parse(N["page_background_color"][3], CultureInfo.InvariantCulture));
+            pageBottomColor = new Color(
+                float.Parse(N["page_panel_color"][0], CultureInfo.InvariantCulture),
+                float.Parse(N["page_panel_color"][1], CultureInfo.InvariantCulture),
+                float.Parse(N["page_panel_color"][2], CultureInfo.InvariantCulture),
+                float.Parse(N["page_panel_color"][3], CultureInfo.InvariantCulture));
+            highlightColor = new Color(
+                float.Parse(N["highlight_color"][0], CultureInfo.InvariantCulture),
+                float.Parse(N["highlight_color"][1], CultureInfo.InvariantCulture),
+                float.Parse(N["highlight_color"][2], CultureInfo.InvariantCulture),
+                float.Parse(N["highlight_color"][3], CultureInfo.InvariantCulture));
             sliderValue = N["background_transparency"].AsFloat;
             showBottomPanel = N["show_bottom_panel"].AsBool;
             showPageNumber = N["show_page_number"].AsBool;
@@ -772,7 +785,11 @@ namespace QuestionnaireToolkit.Scripts
                                 elem.wordSpacing = qItems[j]["word_spacing"].AsFloat;
                                 elem.lineSpacing = qItems[j]["line_spacing"].AsFloat;
                                 var cc = qItems[j]["color"].Value.Split(',');
-                                elem.color = new Color(float.Parse(cc[0].Substring(5)), float.Parse(cc[1]), float.Parse(cc[2]), float.Parse(cc[3].Trim(')')));
+                                elem.color = new Color(
+                                    float.Parse(cc[0].Substring(5), CultureInfo.InvariantCulture),
+                                    float.Parse(cc[1], CultureInfo.InvariantCulture),
+                                    float.Parse(cc[2], CultureInfo.InvariantCulture),
+                                    float.Parse(cc[3].Trim(')'), CultureInfo.InvariantCulture));
                                 elem.alignment = (TextAlignmentOptions) Enum.Parse( typeof(TextAlignmentOptions), qItems[j]["alignment"].Value );
                                 elem.enableWordWrapping = qItems[j]["word_wrapping"].AsBool;
                                 elem.overflowMode = (TextOverflowModes) Enum.Parse( typeof(TextOverflowModes), qItems[j]["overflow_mode"].Value );
@@ -1425,7 +1442,12 @@ namespace QuestionnaireToolkit.Scripts
                     
                     // add the current question item value as objective function value
                     // addObjectiveValue("Trust", 3f);
-                    if (boManager) { boForUnity.optimizer.AddObjectiveValue(resultsHeaderItems[boCounter], float.Parse(currVal)); }
+                    if (boManager)
+                    {
+                        boForUnity.optimizer.AddObjectiveValue(
+                            resultsHeaderItems[boCounter],
+                            float.Parse(currVal, CultureInfo.InvariantCulture));
+                    }
                     boCounter++;
                 }
             }
@@ -1438,7 +1460,12 @@ namespace QuestionnaireToolkit.Scripts
                     line += "\"" + currVal + "\",";
                     
                     // also add the additional csv item values defined in the inspector of the QTQuestionnaireManager
-                    if (boManager) { boForUnity.optimizer.AddObjectiveValue(resultsHeaderItems[boCounter], float.Parse(currVal)); }
+                    if (boManager)
+                    {
+                        boForUnity.optimizer.AddObjectiveValue(
+                            resultsHeaderItems[boCounter],
+                            float.Parse(currVal, CultureInfo.InvariantCulture));
+                    }
                     boCounter++;
                 }
                 else


### PR DESCRIPTION
## Summary
- parse network coverage values with `CultureInfo.InvariantCulture` so comma-based locales don't break incoming floats
- import questionnaire color and objective values using invariant culture to accept JSON decimals regardless of user locale

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d50a0b59fc832c8bae499f41cd5c2e