### PR TITLE
Guard success message on expected optimization completion

### DIFF
--- a/Assets/BOforUnity/Scripts/SocketNetwork.cs
+++ b/Assets/BOforUnity/Scripts/SocketNetwork.cs
@@ -79,6 +79,8 @@ namespace BOforUnity.Scripts
         private IPEndPoint _ipEnd;
         private Thread _connectThread;
         private volatile bool _stopRequested;
+        private volatile bool _connectionClosedByPeer;
+        private volatile bool _optimizationFinished;
 
         public float coverage = 0f;
         public float tempCoverage = 0f;
@@ -104,6 +106,8 @@ namespace BOforUnity.Scripts
             _ipEnd = new IPEndPoint(_ip, 56001);
 
             _stopRequested = false;
+            _connectionClosedByPeer = false;
+            _optimizationFinished = false;
             _connectThread = new Thread(SocketReceive) { IsBackground = true };
             _connectThread.Start();
         }
@@ -126,7 +130,18 @@ namespace BOforUnity.Scripts
                     int recvLen = _serverSocket.Receive(_recvBuf);
                     if (recvLen == 0)
                     {
-                        Debug.Log("Connection closed by server");
+                        _connectionClosedByPeer = true;
+
+                        if (_optimizationFinished)
+                        {
+                            Debug.Log("Python optimization process closed the connection. Optimization iterations have finished successfully.");
+                        }
+                        else
+                        {
+                            Debug.LogError("Socket closed by Python unexpectedly before optimization completed.");
+                            MainThreadDispatcher.Execute(OnSocketConnectionFailed);
+                        }
+
                         SocketQuit();
                         break;
                     }
@@ -154,8 +169,15 @@ namespace BOforUnity.Scripts
             }
             catch (SocketException ex)
             {
-                Debug.LogError($"SocketReceive SocketException: {ex.SocketErrorCode} {ex.Message}");
-                MainThreadDispatcher.Execute(OnSocketConnectionFailed);
+                if (_stopRequested || _connectionClosedByPeer)
+                {
+                    Debug.Log("Socket connection closed.");
+                }
+                else
+                {
+                    Debug.LogError($"SocketReceive SocketException: {ex.SocketErrorCode} {ex.Message}");
+                    MainThreadDispatcher.Execute(OnSocketConnectionFailed);
+                }
             }
             catch (Exception ex)
             {
@@ -227,6 +249,7 @@ namespace BOforUnity.Scripts
                         _bomanager.optimizationFinished = true;
                         _bomanager.OptimizationDone();
                     });
+                    _optimizationFinished = true;
                     break;
                 }
 


### PR DESCRIPTION
## Summary
- maintain tracking to detect when the Python peer closes the socket
- log the completion message only after an explicit optimization_finished signal and surface unexpected closures as errors
- avoid treating intentional socket closures as connection failures

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e674df5348832cbe9bd2ceb820f731